### PR TITLE
Resolution to Issue #2

### DIFF
--- a/apachebuddy.pl
+++ b/apachebuddy.pl
@@ -1002,6 +1002,10 @@ else {
 
 	# determine what user apache runs as 
 	my $apache_user = find_master_value(\@config_array, $model, 'user');
+	if (length($apache_user) > 8) {
+                $apache_user = `id -u $apache_user`;
+                chomp($apache_user);
+        }
 	print "Apache runs as ".$apache_user."\n";
 
 	# determine what the max clients setting is 


### PR DESCRIPTION
ps will print UIDs if a process' user's length is over 8.  Added check to use UID if length is over 8.  This fixes #2.
