### PR TITLE
Debian directory globbing for issue #3

### DIFF
--- a/apachebuddy.pl
+++ b/apachebuddy.pl
@@ -121,6 +121,13 @@ sub find_included_files {
 				}
 
 				# check for file globbing
+
+				if(-d $_ && $_ !~ /\*$/) {
+					print "VERBOSE: Adding glob to ".$_.", is a directory\n" if $main::VERBOSE;
+					$_ .= "/" if($_ !~ /\/$/);
+					$_ .= "*";
+				}
+
 				if ( $_ =~ m/.*\*.*/ ) {
 					my $glob = $_;
 					my @include_files;


### PR DESCRIPTION
Debian / Ubuntu configs (just Rackspace's ?) did not have a glob at the end, e.g., "Include /etc/apache2/sites-enabled/".
Signed-off-by: TonyB hiretonyb@gmail.com
