### PR TITLE
Remove Carriage Return from Config Lines.

### DIFF
--- a/apachebuddy.pl
+++ b/apachebuddy.pl
@@ -206,6 +206,9 @@ sub find_master_value {
 		if ( $_ !~ m/^\s*#/ ) {
 			chomp($_);
 
+			# remove Windows format Carriage Return
+			$_ =~ s/\r//g;
+
 			# we ignore lines that are within a Directory, Location, 
 			# File, or Virtualhost block
 		


### PR DESCRIPTION
For Issue #8. Windows Carriage Returns crashed program by including the CR in the variable $apache_user.

Signed-off-by: TonyB hiretonyb@gmail.com
