### PR TITLE
make MPM itk pretend it's prefork

### DIFF
--- a/apachebuddy.pl
+++ b/apachebuddy.pl
@@ -482,9 +482,13 @@ sub get_apache_conf_file {
 # model based on the way the binary was built
 sub get_apache_model {
 	my ( $process_name ) = @_;
-	my $model = `$process_name -l | egrep "worker.c|prefork.c"`;
+	my $model = `$process_name -l | egrep "worker.c|prefork.c|itk.c"`;
 	chomp($model);
 	$model =~ s/\s*(.*)\.c/$1/;
+
+  if ( $model eq 'itk' ) {
+    $model = 'prefork' ;
+  }
 
 	# return the name of the MPM, or 0 if there is no result
 	if ( $model eq '' ) {


### PR DESCRIPTION
Adding 2 small changes to apachebuddy can do it's full magic when Apache is installed with the MPM-itk module: http://mpm-itk.sesse.net/

As the documentation states: "mpm-itk is based on the traditional prefork MPM" .
